### PR TITLE
feat(client): enable VSCodium support

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-commit-pro-extension",
   "displayName": "CommitPro",
-  "version": "0.1.3",
+  "version": "0.1.4-rc.0",
   "private": true,
   "description": "Write your Commit Message like a pro - like you write your Code",
   "keywords": [


### PR DESCRIPTION
VSCodium's binary is called `codium` instead of the default `code` So, we check for both, and use the one that's available

The limitation of the approach implemented in this commit is that, if both `code` and `codium` are available, it'll always choose `code` regardless of the actual VS Code instance that's running the command.